### PR TITLE
Remove covermode and add codecov badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: false
 install: true
 script:
   - go build -a -o $GOPATH/bin/password-manager github.com/lpegoraro/password-manager/password-manager
-  - go test -coverprofile=coverage.out -covermode=atomic ./...
+  - go test -coverprofile=coverage.out ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.com/lpegoraro/password-manager.svg?branch=master)](https://travis-ci.com/lpegoraro/password-manager)
 [![Join the chat at https://gitter.im/password-manager-go/community](https://badges.gitter.im/password-manager-go/community.svg)](https://gitter.im/password-manager-go/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov](https://codecov.io/gh/lpegoraro/password-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/lpegoraro/password-manager)
 
 POC created to test and enhance Go skills
 


### PR DESCRIPTION
Continued from #37 to implement #35 
- Remove `covermode` in travis.yml (set `covermode` default to `set`)
- Add `codecov` badge